### PR TITLE
Adds validation to webform email configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# linguist configuration for syntax highlighting in github UI.
+*.module linguist-language=PHP
+*.install linguist-language=PHP
+*.theme linguist-language=PHP

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Drupal configuration for Bay hosting platform integrations.
 - Ensures dependencies required for the Bay hosting platform are installed.
 - Allows configuring the default `Reply-To` email address via `SMTP_REPLYTO`
   environment variable.
+- Adds validation to webform email handler form, restricting configuration 
+  emails configured in SMTP_WHITELIST envvar.

--- a/bay_platform_dependencies.module
+++ b/bay_platform_dependencies.module
@@ -11,67 +11,67 @@ const BPD_ENV_SMTP_ALLOWLIST = "SMTP_FROM_WHITELIST";
  * Implements hook_mail_alter().
  */
 function bay_platform_dependencies_mail_alter(&$message) {
-    // Ensures that the Reply-To header points to a no-reply address if it is
-    // using the default value. This is to ensure the SES verified address
-    // doesn't get spammed. The second check ensures that modules which change
-    // the reply-to (such as webform) still function correctly.
-    //
-    // The SMTP_REPLYTO environment variable is set in lagoon.
-    $reply_to = getenv("SMTP_REPLYTO") ?: '';
-    if ($reply_to && ($message['from'] == $message['reply-to'])) {
-        $message['reply-to'] = $reply_to;
-        $message['headers']['Reply-to'] = $reply_to;
-    }
+  // Ensures that the Reply-To header points to a no-reply address if it is
+  // using the default value. This is to ensure the SES verified address
+  // doesn't get spammed. The second check ensures that modules which change
+  // the reply-to (such as webform) still function correctly.
+  //
+  // The SMTP_REPLYTO environment variable is set in lagoon.
+  $reply_to = getenv("SMTP_REPLYTO") ?: '';
+  if ($reply_to && ($message['from'] == $message['reply-to'])) {
+    $message['reply-to'] = $reply_to;
+    $message['headers']['Reply-to'] = $reply_to;
+  }
 }
 
 /**
  * Implements hook_form_FORM_ID_alter().
  */
 function bay_platform_dependencies_form_webform_handler_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state) {
-    $smtp_allowlist = _bay_platform_dependencies_smtp_allowlist();
-    if (!$smtp_allowlist) {
-        return;
-    }
-
-    _bay_platform_dependencies_form_webform_handler_form_options($form["settings"]["from"]["from_mail"]["from_mail"], $smtp_allowlist);
-
-    $restricted_additional_elements = [
-        "return_path",
-        "sender_mail",
-    ];
-    foreach ($restricted_additional_elements as $element) {
-        _bay_platform_dependencies_form_webform_handler_form_options($form["settings"]["additional"][$element][$element], $smtp_allowlist);
-    }
+  $smtp_allowlist = _bay_platform_dependencies_smtp_allowlist();
+  if (!$smtp_allowlist) {
+    return;
+  }
+  
+  _bay_platform_dependencies_form_webform_handler_form_options($form["settings"]["from"]["from_mail"]["from_mail"], $smtp_allowlist);
+  
+  $restricted_additional_elements = [
+    "return_path",
+    "sender_mail",
+  ];
+  foreach ($restricted_additional_elements as $element) {
+    _bay_platform_dependencies_form_webform_handler_form_options($form["settings"]["additional"][$element][$element], $smtp_allowlist);
+  }
 }
 
 function _bay_platform_dependencies_form_webform_handler_form_options(&$element, array $smtp_allowlist) {
-    // Remove ability to choose element values.
-    unset($element['#options']["Elements"]);
-    unset($element['#options']["Options"]);
-
-    // Remove ability to choose contextual values.
-    $element['#options']["Other"] = [];
-    foreach ($smtp_allowlist as $email) {
-        $element['#options']["Other"][$email] = $email;
-    }
-
-    // Add validation to ensure "other" values meet allowlist.
-    $element["#element_validate"][] = "bay_platform_dependencies_form_webform_handler_form_element_validate";
+  // Remove ability to choose element values.
+  unset($element['#options']["Elements"]);
+  unset($element['#options']["Options"]);
+  
+  // Remove ability to choose contextual values.
+  $element['#options']["Other"] = [];
+  foreach ($smtp_allowlist as $email) {
+    $element['#options']["Other"][$email] = $email;
+  }
+  
+  // Add validation to ensure "other" values meet allowlist.
+  $element["#element_validate"][] = "bay_platform_dependencies_form_webform_handler_form_element_validate";
 }
 
 /**
  * Validation handler for email options elements.
  */
 function bay_platform_dependencies_form_webform_handler_form_element_validate($element, &$form_state) {
-    $value = $form_state->getValue($element['#parents']);
-    if (empty($value) || $value == "_default") {
-        return;
-    }
-
-    if (!in_array($value, _bay_platform_dependencies_smtp_allowlist())) {
-        $error = \Drupal::translation()->translate("Disallowed email address submitted - %email", ["%email" => $value]);
-        $form_state->setErrorByName(implode("][", $element['#parents']), $error);
-    }
+  $value = $form_state->getValue($element['#parents']);
+  if (empty($value) || $value == "_default") {
+    return;
+  }
+  
+  if (!in_array($value, _bay_platform_dependencies_smtp_allowlist())) {
+    $error = \Drupal::translation()->translate("Disallowed email address submitted - %email", ["%email" => $value]);
+    $form_state->setErrorByName(implode("][", $element['#parents']), $error);
+  }
 }
 
 /**
@@ -82,9 +82,9 @@ function bay_platform_dependencies_form_webform_handler_form_element_validate($e
  *  FALSE is not configured.
  */
 function _bay_platform_dependencies_smtp_allowlist() {
-    $list = getenv(BPD_ENV_SMTP_ALLOWLIST);
-    if (empty($list)) {
-        return FALSE;
-    }
-    return explode(",", $list);
+  $list = getenv(BPD_ENV_SMTP_ALLOWLIST);
+  if (empty($list)) {
+    return FALSE;
+  }
+  return explode(",", $list);
 }

--- a/bay_platform_dependencies.module
+++ b/bay_platform_dependencies.module
@@ -69,7 +69,8 @@ function bay_platform_dependencies_form_webform_handler_form_element_validate($e
     }
 
     if (!in_array($value, _bay_platform_dependencies_smtp_allowlist())) {
-        $form_state->setErrorByName(implode("][", $element['#parents']), t("Disallowed email address submitted - %email", ["%email" => $value]));
+        $error = \Drupal::translation()->translate("Disallowed email address submitted - %email", ["%email" => $value]);
+        $form_state->setErrorByName(implode("][", $element['#parents']), $error);
     }
 }
 
@@ -82,7 +83,7 @@ function bay_platform_dependencies_form_webform_handler_form_element_validate($e
  */
 function _bay_platform_dependencies_smtp_allowlist() {
     $list = getenv(BPD_ENV_SMTP_ALLOWLIST);
-    if (!empty($list)) {
+    if (empty($list)) {
         return FALSE;
     }
     return explode(",", $list);

--- a/bay_platform_dependencies.module
+++ b/bay_platform_dependencies.module
@@ -34,14 +34,8 @@ function bay_platform_dependencies_form_webform_handler_form_alter(&$form, \Drup
   }
   
   _bay_platform_dependencies_form_webform_handler_form_options($form["settings"]["from"]["from_mail"]["from_mail"], $smtp_allowlist);
-  
-  $restricted_additional_elements = [
-    "return_path",
-    "sender_mail",
-  ];
-  foreach ($restricted_additional_elements as $element) {
-    _bay_platform_dependencies_form_webform_handler_form_options($form["settings"]["additional"][$element][$element], $smtp_allowlist);
-  }
+  _bay_platform_dependencies_form_webform_handler_form_options($form["settings"]["additional"]["return_path"]["return_path"], $smtp_allowlist);
+  _bay_platform_dependencies_form_webform_handler_form_options($form["settings"]["additional"]["sender_mail"]["sender_mail"], $smtp_allowlist);
 }
 
 function _bay_platform_dependencies_form_webform_handler_form_options(&$element, array $smtp_allowlist) {

--- a/bay_platform_dependencies.module
+++ b/bay_platform_dependencies.module
@@ -5,19 +5,85 @@
  * Primary module hooks for bay-platform-dependencies module.
  */
 
+const BPD_ENV_SMTP_ALLOWLIST = "SMTP_FROM_WHITELIST";
+
 /**
  * Implements hook_mail_alter().
  */
 function bay_platform_dependencies_mail_alter(&$message) {
-  // Ensures that the Reply-To header points to a no-reply address if it is
-  // using the default value. This is to ensure the SES verified address
-  // doesn't get spammed. The second check ensures that modules which change
-  // the reply-to (such as webform) still function correctly.
-  //
-  // The SMTP_REPLYTO environment variable is set in lagoon.
-  $reply_to = getenv("SMTP_REPLYTO") ?: '';
-  if ($reply_to && ($message['from'] == $message['reply-to'])) {
-    $message['reply-to'] = $reply_to;
-    $message['headers']['Reply-to'] = $reply_to;
-  }
+    // Ensures that the Reply-To header points to a no-reply address if it is
+    // using the default value. This is to ensure the SES verified address
+    // doesn't get spammed. The second check ensures that modules which change
+    // the reply-to (such as webform) still function correctly.
+    //
+    // The SMTP_REPLYTO environment variable is set in lagoon.
+    $reply_to = getenv("SMTP_REPLYTO") ?: '';
+    if ($reply_to && ($message['from'] == $message['reply-to'])) {
+        $message['reply-to'] = $reply_to;
+        $message['headers']['Reply-to'] = $reply_to;
+    }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function bay_platform_dependencies_form_webform_handler_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state) {
+    $smtp_allowlist = _bay_platform_dependencies_smtp_allowlist();
+    if (!$smtp_allowlist) {
+        return;
+    }
+
+    _bay_platform_dependencies_form_webform_handler_form_options($form["settings"]["from"]["from_mail"]["from_mail"], $smtp_allowlist);
+
+    $restricted_additional_elements = [
+        "return_path",
+        "sender_mail",
+    ];
+    foreach ($restricted_additional_elements as $element) {
+        _bay_platform_dependencies_form_webform_handler_form_options($form["settings"]["additional"][$element][$element], $smtp_allowlist);
+    }
+}
+
+function _bay_platform_dependencies_form_webform_handler_form_options(&$element, array $smtp_allowlist) {
+    // Remove ability to choose element values.
+    unset($element['#options']["Elements"]);
+    unset($element['#options']["Options"]);
+
+    // Remove ability to choose contextual values.
+    $element['#options']["Other"] = [];
+    foreach ($smtp_allowlist as $email) {
+        $element['#options']["Other"][$email] = $email;
+    }
+
+    // Add validation to ensure "other" values meet allowlist.
+    $element["#element_validate"][] = "bay_platform_dependencies_form_webform_handler_form_element_validate";
+}
+
+/**
+ * Validation handler for email options elements.
+ */
+function bay_platform_dependencies_form_webform_handler_form_element_validate($element, &$form_state) {
+    $value = $form_state->getValue($element['#parents']);
+    if (empty($value) || $value == "_default") {
+        return;
+    }
+
+    if (!in_array($value, _bay_platform_dependencies_smtp_allowlist())) {
+        $form_state->setErrorByName(implode("][", $element['#parents']), t("Disallowed email address submitted - %email", ["%email" => $value]));
+    }
+}
+
+/**
+ * Helper function which returns the permitted email addresses.
+ *
+ * @returns array|bool
+ *  Array of allowed emails, or
+ *  FALSE is not configured.
+ */
+function _bay_platform_dependencies_smtp_allowlist() {
+    $list = getenv(BPD_ENV_SMTP_ALLOWLIST);
+    if (!empty($list)) {
+        return FALSE;
+    }
+    return explode(",", $list);
 }


### PR DESCRIPTION
## Motivation

This PR aims to prevent webform emails being configured incorrectly. 

## Changes

The following apply to the `From`, `Sender`, and `Return-path` configuration form elements.
- Removes as many invalid options as possible.
- Adds validation to prevent specifying custom values that are invalid (this is due to webform enforcing the presence of an "other" select option).