### PR TITLE
Updated section purge upstream link.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "drush/drush": "^11",
     "drupal/purge": "^3.4",
-    "drupal/section_purge": "dev-3307199-drupal-10-compatibility",
+    "drupal/section_purge": "4.x",
     "drupal/section_purger": "dev-updates_to_compatible_with_drupal_9",
     "drupal/redis": "1.6",
     "drupal/smtp": "^1.2",
@@ -34,15 +34,7 @@
   "repositories": {
     "drupal": {
       "type": "composer",
-      "url": "https://packages.drupal.org/8",
-      "exclude": [
-        "drupal/section_purge"
-      ]
-    },
-    "drupal/section_purge": {
-      "type": "vcs",
-      "no-api": true,
-      "url": "https://github.com/dpc-sdp/section_purge.git"
+      "url": "https://packages.drupal.org/8"
     },
     "dpc-sdp/bay_monitoring": {
       "no-api": true,


### PR DESCRIPTION
### Changes
@krakerag has released a new branch 4.x for section purge with the branch name fixing, so reverting back the upstream link for section purge and the package should be available in composer - https://git.drupalcode.org/project/section_purge/-/tree/4.x?ref_type=heads
