### PR TITLE
Implement a custom token which reads the k8s service account token

### DIFF
--- a/bay_platform_dependencies.module
+++ b/bay_platform_dependencies.module
@@ -85,6 +85,9 @@ function _bay_platform_dependencies_smtp_allowlist() {
   return explode(",", $list);
 }
 
+/**
+ * Implements hook_token_info().
+ */
 function bay_platform_dependencies_token_info() {
   $info = [];
 

--- a/bay_platform_dependencies.module
+++ b/bay_platform_dependencies.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Render\BubbleableMetadata;
 
 const BPD_ENV_SMTP_ALLOWLIST = "SMTP_FROM_WHITELIST";
+const K8S_SERVICE_ACCOUNT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";
 
 /**
  * Implements hook_mail_alter().
@@ -108,9 +109,12 @@ function bay_platform_dependencies_tokens($type, $tokens, array $data, array $op
     foreach ($tokens as $name => $original) {
       switch ($name) {
         case 'k8s-service-account-token':
-          if (file_exists('/var/run/secrets/kubernetes.io/serviceaccount/token')) {
-            $token = file_get_contents('/var/run/secrets/kubernetes.io/serviceaccount/token');
-            ($token === FALSE) ? $replacements[$original] = '' : $replacements[$original] = $token;
+          if (file_exists(K8S_SERVICE_ACCOUNT_PATH)) {
+            $token = file_get_contents(K8S_SERVICE_ACCOUNT_PATH);
+            if ($token === FALSE) {
+              throw new \Exception(sprintf("Failed to read service account token at %s", K8S_SERVICE_ACCOUNT_PATH));
+            }
+            $replacements[$original] = $token;
           } else {
             $replacements[$original] = '';
           }

--- a/bay_platform_dependencies.module
+++ b/bay_platform_dependencies.module
@@ -5,6 +5,8 @@
  * Primary module hooks for bay-platform-dependencies module.
  */
 
+use Drupal\Core\Render\BubbleableMetadata;
+
 const BPD_ENV_SMTP_ALLOWLIST = "SMTP_FROM_WHITELIST";
 
 /**
@@ -81,4 +83,37 @@ function _bay_platform_dependencies_smtp_allowlist() {
     return FALSE;
   }
   return explode(",", $list);
+}
+
+function bay_platform_dependencies_token_info() {
+  $info = [];
+
+  $info['tokens']['bay_platform_dependencies']['k8s-service-account-token'] = [
+    'name' => t('Kubernetes Service Account Token'),
+    'description' => t('A token which retrieves the current value from /var/run/secrets/kubernetes.io/serviceaccount/token.'),
+  ];
+
+  return $info;
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function bay_platform_dependencies_tokens($type, $tokens, array $data, array $options, BubbleableMetadata $bubbleable_metadata) {
+  $replacements = [];
+  if ($type == 'bay_platform_dependencies') {
+    foreach ($tokens as $name => $original) {
+      switch ($name) {
+        case 'k8s-service-account-token':
+          if (file_exists('/var/run/secrets/kubernetes.io/serviceaccount/token')) {
+            $token = file_get_contents('/var/run/secrets/kubernetes.io/serviceaccount/token');
+            ($token === FALSE) ? $replacements[$original] = '' : $replacements[$original] = $token;
+          } else {
+            $replacements[$original] = '';
+          }
+          break;
+      }
+    }
+  }
+  return $replacements;
 }


### PR DESCRIPTION
1. Adds a [baywatch:k8s-service-account-token] token for use with the HTTP purger to authenticate with the Estuary middleware.