### PR TITLE
New Relic traces for PhpRedisCluster patch

### DIFF
--- a/bay_platform_dependencies.module
+++ b/bay_platform_dependencies.module
@@ -3,8 +3,6 @@
 /**
  * @file
  * Primary module hooks for bay-platform-dependencies module.
- *
- * Test.
  */
 
 use Drupal\Core\Render\BubbleableMetadata;

--- a/bay_platform_dependencies.module
+++ b/bay_platform_dependencies.module
@@ -3,6 +3,8 @@
 /**
  * @file
  * Primary module hooks for bay-platform-dependencies module.
+ *
+ * Test.
  */
 
 use Drupal\Core\Render\BubbleableMetadata;

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "enable-patching": true,
     "patches": {
       "drupal/redis": {
-        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#mr19-note360450": "https://gist.githubusercontent.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04/raw/aa3ca97d5364dc948d84cf749dc55a12064b159d/drupal-redis-1.8-redis-cluster-newrelic.patch"
+        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#mr19-note360450": "https://git.drupalcode.org/project/redis/-/merge_requests/19.diff"
       }
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "enable-patching": true,
     "patches": {
       "drupal/redis": {
-        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#comment-14779350 with new relic integration": "https://gist.githubusercontent.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04/raw/cb21342af768eea866b8e917b436d75932533757/drupal-redis-1.6-redis-cluster-newrelic.patch"
+        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#comment-14779350 with new relic integration": "https://gist.githubusercontent.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04/raw/2fabac93c279577390fc98717cb9d9273ac965e4/drupal-redis-1.6-redis-cluster-newrelic.patch"
       }
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "enable-patching": true,
     "patches": {
       "drupal/redis": {
-        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#comment-14779350 with new relic integration": "https://gist.githubusercontent.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04/raw/f1e98908806869ad8b1c3388b0374659149567f4/drupal-redis-1.6-redis-cluster-newrelic.patch"
+        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#comment-14779350 with new relic integration": "https://gist.githubusercontent.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04/raw/cb21342af768eea866b8e917b436d75932533757/drupal-redis-1.6-redis-cluster-newrelic.patch"
       }
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "enable-patching": true,
     "patches": {
       "drupal/redis": {
-        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#mr19-note360450": "https://git.drupalcode.org/project/redis/-/merge_requests/19.diff"
+        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#mr19-note360450": "https://gist.githubusercontent.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04/raw/aa3ca97d5364dc948d84cf749dc55a12064b159d/drupal-redis-1.8-redis-cluster-newrelic.patch"
       }
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "drush/drush": "^12",
     "drupal/purge": "^3.4",
     "drupal/section_purge": "4.x",
-    "drupal/redis": "1.6",
+    "drupal/redis": "1.8",
     "drupal/smtp": "^1.2",
     "dpc-sdp/tide_logs": "2.0.0",
     "dpc-sdp/bay_monitoring": "^2.0",
@@ -23,7 +23,7 @@
     "enable-patching": true,
     "patches": {
       "drupal/redis": {
-        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#comment-14779350": "https://www.drupal.org/files/issues/2022-11-10/2900947-57.patch"
+        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#mr19-note360450": "https://git.drupalcode.org/project/redis/-/merge_requests/19.diff"
       }
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "enable-patching": true,
     "patches": {
       "drupal/redis": {
-        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#comment-14779350 with new relic integration": "https://gist.githubusercontent.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04/raw/2fabac93c279577390fc98717cb9d9273ac965e4/drupal-redis-1.6-redis-cluster-newrelic.patch"
+        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#comment-14779350 with new relic integration": "https://gist.githubusercontent.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04/raw/337db16a7910b6f6e8e46369162dd5acec51db18/drupal-redis-1.6-redis-cluster-newrelic.patch"
       }
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "enable-patching": true,
     "patches": {
       "drupal/redis": {
-        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#comment-14779350 with new relic integration": "https://gist.githubusercontent.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04/raw/337db16a7910b6f6e8e46369162dd5acec51db18/drupal-redis-1.6-redis-cluster-newrelic.patch"
+        "Implement initial RedisCluster client integration - https://gist.github.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04 with new relic integration": "https://gist.githubusercontent.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04/raw/337db16a7910b6f6e8e46369162dd5acec51db18/drupal-redis-1.6-redis-cluster-newrelic.patch"
       }
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "enable-patching": true,
     "patches": {
       "drupal/redis": {
-        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#comment-14779350": "https://www.drupal.org/files/issues/2022-11-10/2900947-57.patch"
+        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#comment-14779350 with new relic integration": "https://gist.githubusercontent.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04/raw/f1e98908806869ad8b1c3388b0374659149567f4/drupal-redis-1.6-redis-cluster-newrelic.patch"
       }
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "drush/drush": "^12",
     "drupal/purge": "^3.4",
     "drupal/section_purge": "4.x",
-    "drupal/redis": "1.8",
+    "drupal/redis": "1.6",
     "drupal/smtp": "^1.2",
     "dpc-sdp/tide_logs": "2.0.0",
     "dpc-sdp/bay_monitoring": "^2.0",
@@ -23,7 +23,7 @@
     "enable-patching": true,
     "patches": {
       "drupal/redis": {
-        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#mr19-note360450": "https://git.drupalcode.org/project/redis/-/merge_requests/19.diff"
+        "Implement initial RedisCluster client integration - https://www.drupal.org/project/redis/issues/2900947#comment-14779350": "https://www.drupal.org/files/issues/2022-11-10/2900947-57.patch"
       }
     }
   },


### PR DESCRIPTION
Basically we've taken the patch from https://www.drupal.org/project/redis/issues/2900947#comment-14779350 and added new relic traces around each redis call.

I acknowledge this means we're on a difficult upgrade path for the redis module, at least until the aforementioned issue is merged and included in a stable release.