### PR TITLE
Remove drush sql —extras flag patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
     "patches": {
       "drupal/redis": {
         "Implement initial RedisCluster client integration - https://gist.github.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04 with new relic integration": "https://gist.githubusercontent.com/nicksantamaria/0e0c91aa0a33359f055165b49df59f04/raw/c498a55f3a7a086b38e54e493bf69015a2fa33ed/drupal-redis-1.6-redis-cluster-newrelic.patch"
-      },
-      "drush/drush": {
-        "Add --extra option to sql:create, sql:drop, and site:install": "https://patch-diff.githubusercontent.com/raw/drush-ops/drush/pull/6249.patch"
       }
     }
   },


### PR DESCRIPTION
Changes of this patch has been merged so no need it.

      "drush/drush": {
        "Add --extra option to sql:create, sql:drop, and site:install": "https://patch-diff.githubusercontent.com/raw/drush-ops/drush/pull/6249.patch"

