### PR TITLE
Add cron schedule to Composer validation workflow

### DIFF
--- a/.github/workflows/composer-validate.yml
+++ b/.github/workflows/composer-validate.yml
@@ -1,6 +1,8 @@
 name: PHP Composer Validation and Installation
 
 on:
+  schedule:
+    - cron: '0 0 * * 1'  # Runs at 00:00 UTC every Monday
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/composer-validate.yml` file. The change schedules a PHP Composer validation and installation workflow to run at 00:00 UTC every Monday.

* [`.github/workflows/composer-validate.yml`](diffhunk://#diff-cae80f29bc68191f7b1f8401c3100c4d71b6c15f52b9e418ce33e38beda1a2a7R4-R5): Added a cron schedule to run the workflow at 00:00 UTC every Monday.